### PR TITLE
fix:Retain Cycle by NSTimer

### DIFF
--- a/Wonderful.podspec
+++ b/Wonderful.podspec
@@ -9,5 +9,6 @@ s.source = { :git => 'https://github.com/dsxNiubility/Wonderful.git', :tag => s.
 s.requires_arc = true
 s.ios.deployment_target = '7.0'
 s.source_files = 'Wonderful/*.{h,m}'
+s.dependency 'YYText'
 
 end

--- a/WonderfulDemo/Wonderful.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WonderfulDemo/Wonderful.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
NSTimer 在使用时要比较小心，当设置重复触发，NSTimer对象会强引用注册时的target，如果target本身又持有NSTimer对象，就造成了循环引用，可以通过引入中间对象通过弱引用持有接受回调的对象，然后以这个中间对象注册NSTimer对象，再在中间对象内部把消息转发给实际需要接受NSTimer回调消息的对象。具体可以参考[Weak Reference to NSTimer Target To Prevent Retain Cycle](https://stackoverflow.com/questions/16821736/weak-reference-to-nstimer-target-to-prevent-retain-cycle)